### PR TITLE
Adding storage transfers for NPC's

### DIFF
--- a/src/client/StarterCharacter/StatsHandler.client.lua
+++ b/src/client/StarterCharacter/StatsHandler.client.lua
@@ -21,14 +21,14 @@ local statsConfig: {any} = {
 	--Handles config for stats
 	MaxFood = 100, --Max hunger of the player
 	MaxHydration = 100, --MaxHydration of the player
-	FdDeteriorationRate = 60, --time in seconds between when food stat gos down
-	HydDeteriorationRate = 5, --time in seconds between when hydration stat gos down
-	FdDecrement = 20, --The amount that the food stat is decremented by every FdDeteriorationRate
-	HydDecrement = 20, --The amount that the hydration stat is decremented by every HydDeteriorationRate
-	StarveDmg = 20, --The damage done to a player every StarveDmgRate
-	StarveDmgRate = 5, --rate in seconds that damage is dealt during a starve
-	ThirstDmg = 20, --The damage done to a player every ThirstDmgRate
-	ThirstDmgRate = 5,--rate in seconds that damage is dealt during a thirst
+	FdDeteriorationRate = 120, --time in seconds between when food stat gos down
+	HydDeteriorationRate = 120, --time in seconds between when hydration stat gos down
+	FdDecrement = 5, --The amount that the food stat is decremented by every FdDeteriorationRate
+	HydDecrement = 5, --The amount that the hydration stat is decremented by every HydDeteriorationRate
+	StarveDmg = 5, --The damage done to a player every StarveDmgRate
+	StarveDmgRate = 20, --rate in seconds that damage is dealt during a starve
+	ThirstDmg = 5, --The damage done to a player every ThirstDmgRate
+	ThirstDmgRate = 20,--rate in seconds that damage is dealt during a thirst
 }
 
 local stats: {number} = {

--- a/src/server/NPC/ResourceNPC/MinerNPC.lua
+++ b/src/server/NPC/ResourceNPC/MinerNPC.lua
@@ -52,7 +52,7 @@ function MinerNPC.new(
 	EncumbranceSpeed: {}?,
 	ResourceWhiteList: { string }?,
 	DeathHandler: any,
-	StatsConfig: {}
+	StatsConfig: {}?
 )
 	local self = ResourceNPC.new(
 		Name,

--- a/src/server/NPC/ResourceNPC/ResourceNPC.lua
+++ b/src/server/NPC/ResourceNPC/ResourceNPC.lua
@@ -47,7 +47,7 @@ function ResourceNPC.new(
 	EncumbranceSpeed: {}?,
 	ResourceWhiteList: { string }?,
 	DeathHandler: any,
-	StatsConfig: {}
+	StatsConfig: {}?
 )
 	local self = ToolNPC.new(
 		Name,

--- a/src/server/NPC/ToolNPC.lua
+++ b/src/server/NPC/ToolNPC.lua
@@ -49,7 +49,7 @@ function ToolNPC.new(
 	Backpack: {}?,
 	EncumbranceSpeed: {}?,
 	DeathHandler: any,
-	StatsConfig: {}
+	StatsConfig: {}?
 )
 	local self = BackpackNPC.new(
 		Name,

--- a/src/server/ServerTests/NPCTest.server.lua
+++ b/src/server/ServerTests/NPCTest.server.lua
@@ -293,6 +293,7 @@ local storageConfig = {
 }
 local storageDesc = storageHandler:AddStorageDevice(storageConfig, coalCrate)
 NPC1:SetHomePoint(waypoint1.Position)
+NPC1:CollectItem("Iron", 5)
 NPC1:AddPickaxe(pickaxe, 1)
 NPC1:HarvestResource(coal)
 print("Items collected by NPC is: " .. NPC1:GetItemCount("Coal"))
@@ -300,7 +301,7 @@ NPC1:ReturnHome()
 while NPC1:IsTraversing() do
 	task.wait(1)
 end
-NPC1:TransferItemToStorage("Coal", NPC1:GetItemCount("Coal"), coalCrate)
+NPC1:EmptyInventoryToStorage(coalCrate)
 print("Items NPC has after storing is: " .. NPC1:GetItemCount("Coal"))
 print("Storage contains this amount of coal: " .. storageHandler:GetItemCount("Coal", storageDesc))
 --NPC1:UnequipTool()

--- a/src/server/ServerTests/NPCTest.server.lua
+++ b/src/server/ServerTests/NPCTest.server.lua
@@ -259,14 +259,50 @@ NPC1:Kill()
 --MinerNPC test
 
 --[[
+local StorageHandlerObject = require(ServerScriptService.Server.ItemHandlers.StorageHandler)
+local storageHandler: any = StorageHandlerObject.new("BackpackNPCStorageHandler")
+local waypoints = Workspace:FindFirstChild("PathfindingTest")
+local waypoint1 = waypoints:FindFirstChild("Waypoint1")
 local tools = ReplicatedStorage.Tools
 local pickaxe = tools.Resource.Pickaxes.Pickaxe
-local NPC1 = MinerNPC.new("Miner 1", rigsFolder.DefaultNPC, 100, Vector3.new(0, 10, 0), 16, 1000, 100, 70, 100, {"Coal", "Iron", "Pickaxe"}, nil, nil, {"Coal"})
+local NPC1 = MinerNPC.new(
+	"Miner 1",
+	rigsFolder.DefaultNPC,
+	100,
+	Vector3.new(0, 10, 0),
+	16,
+	1000,
+	100,
+	70,
+	100,
+	{ "Coal", "Iron", "Pickaxe", "Bread", "Water"},
+	nil,
+	nil,
+	{ "Coal" },
+    true,
+	nil
+)
 local coal = workspace:FindFirstChild("OreModelDemo"):FindFirstChild("Coal")
 print(NPC1:IsOre(coal))
+local coalCrate = workspace:FindFirstChild("Coal Crate")
+local storageConfig = {
+	MaxStack = 10,
+	ItemsConfig = {
+		Ore = {"AllItems"}
+	}
+}
+local storageDesc = storageHandler:AddStorageDevice(storageConfig, coalCrate)
+NPC1:SetHomePoint(waypoint1.Position)
 NPC1:AddPickaxe(pickaxe, 1)
 NPC1:HarvestResource(coal)
-print(NPC1:GetItemCount("Coal"))
+print("Items collected by NPC is: " .. NPC1:GetItemCount("Coal"))
+NPC1:ReturnHome()
+while NPC1:IsTraversing() do
+	task.wait(1)
+end
+NPC1:TransferItemToStorage("Coal", NPC1:GetItemCount("Coal"), coalCrate)
+print("Items NPC has after storing is: " .. NPC1:GetItemCount("Coal"))
+print("Storage contains this amount of coal: " .. storageHandler:GetItemCount("Coal", storageDesc))
 --NPC1:UnequipTool()
 --NPC1:Kill()
 --]]


### PR DESCRIPTION
Added the features for the NPC class to transfer an item in the NPC's inventory into a given storage device. In addition also added a dump to storage feature that allows the NPC to dump anything availible and whitelisted into the storage.